### PR TITLE
refactor: using set in return of all_lbz_errors call

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -73,7 +73,7 @@ def test__custom_exception__contains_message_and_status_code_according_to_its_do
 
 
 def test__all_lbz_errors__returns_all_subclasses_of_lambda_fw_exception() -> None:
-    result = list(all_lbz_errors())
+    result = set(all_lbz_errors())
 
     assert BadRequestError in result
     assert ServerError in result


### PR DESCRIPTION
This PR updates the `test__all_lbz_errors__returns_all_subclasses_of_lambda_fw_exception` test to use a `set` instead of a `list` for the `result of all_lbz_errors()`. The change optimizes membership checks (using the in operator) by improving lookup performance from O(n) to O(1). Its not a big optimization, but it makes the checks a bit more efficient

The behavior of the test remains unchanged.